### PR TITLE
add a config to allow parsing options after command method

### DIFF
--- a/src/clite_parser.test.ts
+++ b/src/clite_parser.test.ts
@@ -290,3 +290,20 @@ Options:
      --opt-from-child opt-from-child    [default: 123]`,
   );
 });
+
+Deno.test("testOptionAfterMethodCmd", () => {
+  const result = cliteParse(Tool, {
+    args: ["down", "--opt3=xclkd", "true", "foo"],
+  });
+  assertEquals(result.command, "down");
+  assertEquals(result.obj.opt3, "xclkd");
+  assertEquals(result.commandArgs, [true, "foo"]);
+
+  const result2 = cliteParse(Tool, {
+    args: ["down", "--opt3=xclkd", "true", "foo"],
+    dontParseOptionAfterMethodCmd: true,
+  });
+  assertEquals(result2.command, "down");
+  assertEquals(result2.obj.opt3, "azer");
+  assertEquals(result2.commandArgs, ["--opt3=xclkd", true, "foo"]);
+});

--- a/src/clite_parser.ts
+++ b/src/clite_parser.ts
@@ -47,7 +47,7 @@ export function cliteParse<O extends Obj & { config?: string }>(
   const metadata = getCliteMetadata(obj);
   const help = genHelp(obj, metadata, config);
   try {
-    const parseResult = parseArgs(obj, metadata, config);
+    let parseResult = parseArgs(obj, metadata, config);
 
     if (Object.keys(parseResult.options).includes("help")) {
       return { obj, command: "--help", commandArgs: [], config, help };
@@ -65,9 +65,10 @@ export function cliteParse<O extends Obj & { config?: string }>(
           cause: { clite: true },
         });
       }
-      fillFields(parseResult, obj, metadata, config);
 
       if (metadata.subcommands.includes(command)) {
+        fillFields(parseResult, obj, metadata, config);
+
         const subcommandObj = typeof obj[command] === "function"
           ? new obj[command]()
           : obj[command];
@@ -85,11 +86,13 @@ export function cliteParse<O extends Obj & { config?: string }>(
       }
 
       if (config?.dontParseOptionAfterMethodCmd === undefined) {
-        return cliteParse(obj, {
+        parseResult = parseArgs(obj, metadata, {
           ...config,
           dontParseOptionAfterMethodCmd: false,
         });
       }
+
+      fillFields(parseResult, obj, metadata, config);
 
       const commandArgs = config?.dontConvertCmdArgs
         ? parseResult.commandArgs

--- a/src/clite_parser.ts
+++ b/src/clite_parser.ts
@@ -83,6 +83,14 @@ export function cliteParse<O extends Obj & { config?: string }>(
           cause: { clite: true },
         });
       }
+
+      if (config?.dontParseOptionAfterMethodCmd === undefined) {
+        return cliteParse(obj, {
+          ...config,
+          dontParseOptionAfterMethodCmd: false,
+        });
+      }
+
       const commandArgs = config?.dontConvertCmdArgs
         ? parseResult.commandArgs
         : parseResult.commandArgs.map(convertCommandArg);

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -75,7 +75,7 @@ export function parseArgs<O extends Obj>(
     collect: arrayProp,
     default: defaultValues,
     alias,
-    stopEarly: true,
+    stopEarly: config?.dontParseOptionAfterMethodCmd ?? true,
   });
   for (const key of Object.keys(stdRes)) {
     if (defaultValues[key] === stdRes[key]) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,12 @@ export type CliteRunConfig = {
    * don't convert "true"/"false" to true/false in command arguments, and not to number after --
    */
   dontConvertCmdArgs?: boolean;
+
+  /**
+   * If true, options appearing after a command method in the arguments will not be parsed as options,
+   * but treated as regular command arguments instead. default: false
+   */
+  dontParseOptionAfterMethodCmd?: boolean;
 };
 
 /**


### PR DESCRIPTION
add a config to allow parsing options after command method

```ts
Deno.test("testOptionAfterMethodCmd", () => {
  const result = cliteParse(Tool, {
    args: ["down", "--opt3=xclkd", "true", "foo"],
  });
  assertEquals(result.command, "down");
  assertEquals(result.obj.opt3, "xclkd");
  assertEquals(result.commandArgs, [true, "foo"]);

  const result2 = cliteParse(Tool, {
    args: ["down", "--opt3=xclkd", "true", "foo"],
    dontParseOptionAfterMethodCmd: true,
  });
  assertEquals(result2.command, "down");
  assertEquals(result2.obj.opt3, "azer");
  assertEquals(result2.commandArgs, ["--opt3=xclkd", true, "foo"]);
});
```